### PR TITLE
Old reference updated

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -265,7 +265,7 @@
         <string/>
        </property>
        <property name="textFormat">
-        <enum>Qt::LogText</enum>
+        <enum>Qt::PlainText</enum>
        </property>
        <property name="pixmap">
         <pixmap resource="../bitcoin.qrc">:/icons/drmbg</pixmap>


### PR DESCRIPTION
Qt::LogText doesn't exist any longer.  Using Qt::PlainText instead.